### PR TITLE
🍪/📌 reactions, / commands, bug fixes

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,5 +1,4 @@
 import asyncio
-
 import discord
 from discord import MessageType, ChannelType
 from discord.ext import commands
@@ -21,7 +20,7 @@ class Admin(commands.Cog):
         reply = await ctx.send(f'{len(deleted) - 1} message(s) purged')
         await reply.delete(delay=1)
 
-    @commands.hybrid_command()
+    @commands.command()
     @commands.has_permissions(manage_guild=True)
     async def status(self, ctx):
         """Set the bot's playing status"""
@@ -116,38 +115,40 @@ Note: {count} role(s) with no members had to be skipped due to having a greater 
         await timewarning.delete()
         await ctx.message.delete()
 
+
     @commands.Cog.listener()
-    async def on_message(self, message: discord.Message):
+    async def on_message(self, message: discord.Message): # known bug: wont act as media channel if channel contains text 'original' or 'selfies'
         """Automatically delete non-media messages in media channels and add 📌 reaction to media messages"""
+        if message.channel.name.find('original') > -1 or message.channel.name.find('selfies') > -1:  # looks for the position of substring. if it's not found, this returns -1.
+            await asyncio.sleep(2.500) #wait for embeds
+            if len(message.embeds) + len(message.attachments) > 0:
+                await message.add_reaction('📌')
+                await message.add_reaction('🍪')
+                return
+        
         if message.author.id == self.bot.user.id:
             return
-        # We need to check if it is a member because webhook message authors are not members and can't have permissions.
+        # We need to check if it is a member in addition since webhook message authors are not members and can't have permissions.
         if message.author is discord.Member and message.author.guild_permissions.administrator:
             return
-        if message.type not in (MessageType.default, MessageType.reply):
-            return
         if message.channel.type != ChannelType.text:
+            return
+        if message.type not in (MessageType.default, MessageType.reply):
             return
         if message.channel.name.find(
                 'media') == -1:  # looks for the position of substring. if it's not found, this returns -1.
             return
-        # We need to wait a bit in-case discord generates embeds or adds attachments.
-        await asyncio.sleep(2.500)
+        
+        await asyncio.sleep(2.500) #wait for embeds
         if len(message.embeds) + len(message.attachments) > 0:
             await message.add_reaction('📌')  # doesn't check if channel is private, only if media isn't in the name
             return
         try:
+            await message.channel.send(f'<@{message.author.id}> Sorry, you can\'t talk in media channels, but you can start a thread! if you posted media, try again and make sure it embedded properly',
+                                       delete_after=8)
             await message.delete()
-            await message.channel.send('Unfortunately, you can\'t talk in media channels. You have to send either \
-an attachment or embed with your message. If you sent a link, discord timed out and didn\'t embed the message. \
-(discord can struggle to do this when the file size is large, especially when their servers are being slow). \
-You can try again, or you can download whatever is at the link and upload it to discord manually. Don\'t be afraid to \
-try multiple times. This is all a discord limitation we can\'t do anything about at the moment. Sorry :(',
-                                       delete_after=12)
-        except discord.NotFound:
-            # Message was already deleted.
+        except discord.NotFound: # Message was already deleted.
             pass
-
 
 async def setup(bot):
     await bot.add_cog(Admin(bot))

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -40,7 +40,7 @@ class Fun(commands.Cog):
         if not num.isdigit():
             num = "1"
         if not sides.isdigit():
-            await ctx.send(f'<@{ctx.author.id}> I\'m not sure i get it... <:MeruSad:633650580660682762> \
+            await ctx.send(f'<@{ctx.author.id}> I\'m not sure i get it... <:MeruSad:935943233626861568> \
 Could you try it like this? <:QuestionBun:588539387688517642> \n\
 `.roll d[number of sides] [number of dice]`')
         elif int(sides) == 0 or int(num) == 0:

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -10,7 +10,6 @@ class Misc(commands.Cog):
     @commands.command()
     async def faq(self, ctx):
         """FAQ/Copypasta list"""
-        await ctx.message.delete()
         await ctx.send('''
 ## Gay Baby Jail - Frequently Asked Questions
 Below is a list of commands you can use to either learn more about the server or quickly educate others
@@ -19,10 +18,9 @@ Below is a list of commands you can use to either learn more about the server or
 * Other: `.feedback`, `.roleplay`, `.textrules`, `.lights`, `.discussion`, `.mediaguide`
 ''')
 
-    @commands.command()
+    @commands.hybrid_command()
     async def economy(self, ctx):
         """copypasta command explaining all the ways to earn cookies in the economy"""
-        await ctx.message.delete()
         await ctx.send('''
 # Learn how to succeed in the GBJ economy
 ## Earning Cookies
@@ -43,10 +41,9 @@ Redemption for these is manual. To claim your cookies, <#1172337920431104053>. I
 - To see all the roles you can purchase, type `.allroles`.
 ''')
 
-    @commands.command(aliases=["diaperserver"])
+    @commands.hybrid_command(aliases=["diaperserver"])
     async def discussion(self, ctx):
         """copypasta command explaining why we allow and encourage serious or adult conversations"""
-        await ctx.message.delete()
         await ctx.send(
             '''Gay Baby Jail is not _just_ a diaper server. Its mostly a hangout server where diapers are normalized. \
 We don't allow roleplay or baby-talk in the generals, and we're all adults. While serious topics aren't always being \
@@ -57,10 +54,9 @@ If the current topic makes you uncomfortable, we have other channels, and there'
 visit in the meantime as well. Thank you for your understanding.
 ''')
 
-    @commands.command()
+    @commands.hybrid_command()
     async def modmail(self, ctx):
         """copypasta command explaining modmail"""
-        await ctx.message.delete()
         await ctx.send('''\
 # How do I contact the GBJ staff?
 Head to <#1172337920431104053>, and click `Open a ticket!`. This will put you in a channel with staff only, where you can express your concerns.
@@ -71,10 +67,9 @@ If you need to submit a formal complaint against another moderator, we still urg
 If you believe it's urgent, and the server is in danger, you may message any of the available babysitters individually. Abusing this may result in a warning.
 ''')
 
-    @commands.command(aliases=["mediaguide", "media", "mediaguidelines"])
+    @commands.hybrid_command(aliases=["mediaguide", "media", "mediaguidelines"])
     async def mediaguideline(self, ctx):
         """copypasta command explaining what kind of images are allowed in media channels"""
-        await ctx.message.delete()
         await ctx.send('''\
 Images which have the intention of being (abdl-)memes rather than "abdl-media" should be posted in \
 <#639395194898219011>, and should not be posted in media channels. Posts in media channels must somehow pass as art, \
@@ -83,10 +78,9 @@ or aesthetic response in greater or equal proportion to memetic value. Bonus poi
 it when you see it".
 [**Here's a few examples of what and what not to post in media channels (img-link)**](https://files.catbox.moe/e3vxwj.png)''')
 
-    @commands.command(aliases=["pk"])
+    @commands.hybrid_command(aliases=["pk"])
     async def pluralkit(self, ctx):
         """copypasta command explaining what pluralkit is"""
-        await ctx.message.delete()
         await ctx.send('''
 ## ____Why Are There Bots Talking?____
 <@!466378653216014359> is a bot designed for plural systems that use Discord. It allows you to register systems, \
@@ -102,10 +96,9 @@ You can learn more about the bot on [PluralKit's website](<https://pluralkit.me/
 or by using `pk;help in <#395837746083528704>`
 You can learn more about plurality on [MoreThanOne.info](<https://morethanone.info/>)''')
 
-    @commands.command(aliases=["listroles", "roleslist", "rolelist"])
+    @commands.hybrid_command(aliases=["listroles", "roleslist", "rolelist"])
     async def allroles(self, ctx):
         """copypasta command that lists all available roles"""
-        await ctx.message.delete()
         await ctx.send('''\
 ## All Custom Roles
 We had to move the list to [this google sheet](<https://bit.ly/3Bd1Zbq>), it doesn't fit in discord anymore!
@@ -114,10 +107,9 @@ We had to move the list to [this google sheet](<https://bit.ly/3Bd1Zbq>), it doe
 `.diapertraining` in <#395837746083528704> for more info.\
 ''')
 
-    @commands.command()
+    @commands.hybrid_command()
     async def diapertraining(self, ctx):
         """copypasta explaining the diapertraining role"""
-        await ctx.message.delete()
         await ctx.send('''\
 ## <:PottyBanned:779149826154823691> What Is This?
 When the Diaper Training role is pinged, all users must prove they're wearing a diaper with a picture. \
@@ -136,20 +128,9 @@ If you would rather not pay, ping `@girl.kisser` or `@Glasswalker` to remove the
 **If you're caught lying or reusing an old photo, you will be banned from the server for 14 days.**
 ''')
 
-    @commands.command(aliases=["suggest", "suggestion"])
-    async def feedback(self, ctx):
-        """copypasta command template"""
-        await ctx.message.delete()
-        await ctx.send('''\
-If you'd like to submit feedback or suggestions to the server, it's bots, etc., you can use \
-`?suggest [your suggestion]`. This will create a poll which is sent to <#466459060258996225>, which helps us to gauge \
-interest and support.
-''')
-
-    @commands.command(aliases=["rule2", "rp"])
+    @commands.hybrid_command(aliases=["rule2", "rp"])
     async def roleplay(self, ctx):
-        """copypasta command template"""
-        await ctx.message.delete()
+        """copypasta explaining our roleplay rule"""
         await ctx.send('''\
 ## Rule 2: No Roleplay (or baby-talk)
 We understand this is a very divisive rule which many don't understand. In short, we haven't curated GBJ to be a \
@@ -177,20 +158,18 @@ can also use `.stamps` to get a list of stamps provided by me, <@!64178829122574
 completely free. Albeit they only work in servers I'm a part of.
 ''')
 
-    @commands.command(aliases=["rules"])
+    @commands.hybrid_command(aliases=["rules"])
     async def textrules(self, ctx):
-        """copypasta command template"""
-        await ctx.message.delete()
+        """copypasta linking our rules on gdocs"""
         await ctx.send('''\
 [Here's a link to our current rules in plain text]\
 (https://docs.google.com/document/d/13pxzthxFImkSLBOit4u4J6QXi2_5cbVq41qcwcnBYFE). \
 You can make a copy by clicking `File > Make a copy` if you need to make it more readable. 
 ''')
 
-    @commands.command()
+    @commands.hybrid_command()
     async def lights(self, ctx):
-        """copypasta command template"""
-        await ctx.message.delete()
+        """copypasta for lights"""
         await ctx.send('''\
 ## Consent Indicators (aka lights)
 * <:LightGreen:749514803822854224>: All clear, everything is going well. I consent.

--- a/cogs/stamps.py
+++ b/cogs/stamps.py
@@ -10,7 +10,6 @@ IMAGE_SUFFIXES = {'.gif', '.jpeg', '.jpg', '.png', '.mp4', '.webm'}
 IMAGE_AND_JSON_SUFFIXES = set(IMAGE_SUFFIXES)
 IMAGE_AND_JSON_SUFFIXES.add('.json')
 
-
 def snake_to_camel(name):
     """Converts snake_case to CamelCase"""
     return "".join(word.capitalize() for word in name.split("_"))
@@ -200,11 +199,11 @@ class Stamps(commands.Cog):
 
         return cmd
 
-    @commands.command()
+    @commands.hybrid_command()
     async def stamps(self, ctx):
         """Prints out a list of stamp categories"""
         categories = " ".join(self.category_names)
-        await ctx.send(f'Here\'s a list of our stamp packs!\nType `{self.bot.command_prefix}[pack-name]` to see a list of the stamps inside of that pack.```{categories}``` Also, you can add stamps in the `!shop`!'.strip())
+        await ctx.send(f'Here\'s a list of our stamp packs!\nType `{self.bot.command_prefix}[pack-name]` to see a list of the stamps inside of that pack.```{categories}``` Also, you can add stamps in the `!shop`!\nPlease note that these cannot be invoked as a / command'.strip())
 
 
 async def setup(bot):


### PR DESCRIPTION
- cookie now adds 🍪/📌 reactions to media messages in selfies and original-works
- cookie will no longer automatically pin messages older than ~3 months
- cookie will now publish non-member (webhook) messages in pinboard
- cookie's "can't send messages in media channels" message is now much more clean
- user-facing commands are now / commands, with the tradeoff that non / invoked copypasta messages dont delete the message which invoked them
- status is no longer a / command
**Bug Fixes**:
https://github.com/sapphic-wallflower/CookieDough.py/issues/26
https://github.com/sapphic-wallflower/CookieDough.py/issues/18
https://github.com/sapphic-wallflower/CookieDough.py/issues/15
https://github.com/sapphic-wallflower/CookieDough.py/issues/13